### PR TITLE
Possibility to configure the variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,45 @@ gulp.src('./views/*.bhtml')
     .pipe(gulp.dest('./dist'));
 ```
 
-index.html
+Input: `index.html`:
 
 ```html
 <p>meow...meow...</p>
 ```
 
-index.js
+Output: `index.js`:
 
 ```javascript
 module.exports = '<p>meow...meow...</p>';
 ```
+
+## Configuration
+
+Optionally, the variable name can be configured:
+
+```javascript
+var jsString = require('gulp-js-string');
+
+gulp.src('./views/*.bhtml')
+    .pipe(jsString(function(file) {
+        return "exports." + file.basename.split('.')[0];
+    }))
+    .pipe(gulp.dest('./dist'));
+```
+
+Input: `index.html`:
+
+```html
+<p>meow...meow...</p>
+```
+
+Output: `index.js`:
+
+```javascript
+exports.index = '<p>meow...meow...</p>';
+```
+
+This is espacially useful if used in combination with `gulp-concat` to merge several files.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var gutil = require('gulp-util');
 var jsStringEscape = require('js-string-escape');
 var through = require('through2');
 
-module.exports = function() {
+module.exports = function(getVarname) {
   var newError = function(e) {
     return new gutil.PluginError('gulp-js-string', e);
   };
@@ -20,7 +20,8 @@ module.exports = function() {
       // convert to vinyl 0.5.x
       var f = new gutil.File(file);
       var string = "'" + jsStringEscape(f.contents.toString(encoding)) + "'";
-      var script = "module.exports = " + string + ";";
+      var varname = getVarname ? getVarname(f) : "module.exports";
+      var script = varname + " = " + string + ";";
       f.contents = new Buffer(script);
       f.extname = '.js';
       return callback(null, f);


### PR DESCRIPTION
Hi,

I love your work. However, for our project we want to merge several template files into one JS file. Thus, the naming of the variable `module.exports` has to be changed for each template file to allow a conflict free merge afterwards (using `gulp-concat`).

This PR adds this possibility without breaking existing behavior.

I'd be glad if you could release it on npm so we can use it in our project.

Cheers
